### PR TITLE
Bug: second, (third,...) rules not working

### DIFF
--- a/Bundle/SearchBundleDBAL/SortingHandler/DefaultSortingHandler.php
+++ b/Bundle/SearchBundleDBAL/SortingHandler/DefaultSortingHandler.php
@@ -62,5 +62,6 @@ class DefaultSortingHandler implements SortingHandlerInterface
                 $query
             );
         }
+        $query->addOrderBy('product.id');
     }
 }

--- a/Components/QueryExtender/QueryExtensionGateway.php
+++ b/Components/QueryExtender/QueryExtensionGateway.php
@@ -66,7 +66,6 @@ class QueryExtensionGateway
         }
 
         $this->orderByFilterChain->extendQuery($alias, $definition, $rule, $queryBuilder);
-        $queryBuilder->addOrderBy('product.id');
     }
 
     /**


### PR DESCRIPTION
move fallback "orderBy" so its called only once:
Now:
[...]ORDER BY swagDefaultSortArticleAttributesAttribute.attr3 ASC, swagDefaultSortPrices.price DESC, product.id ASC
Before:
[...]ORDER BY swagDefaultSortArticleAttributesAttribute.attr3 ASC, product.id ASC, swagDefaultSortPrices.price DESC, product.id ASC
